### PR TITLE
fix build warning: Microsoft.WindowsAzure.Storage version conflict

### DIFF
--- a/Scheduler/DynamicNodeGroups/DynamicNodeGroups/app.config
+++ b/Scheduler/DynamicNodeGroups/DynamicNodeGroups/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/ExpandedPriorities/ExpandedPriorities/app.config
+++ b/Scheduler/ExpandedPriorities/ExpandedPriorities/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/dll/Activation FlexLM/app.config
+++ b/Scheduler/Filters/dll/Activation FlexLM/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/dll/Activation HoldUntil/ActivationHoldUntil/app.config
+++ b/Scheduler/Filters/dll/Activation HoldUntil/ActivationHoldUntil/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/dll/ComboDiagLogging/ComboDiagLogging/app.config
+++ b/Scheduler/Filters/dll/ComboDiagLogging/ComboDiagLogging/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/dll/Submission JobSize/SubmissionJobSize/app.config
+++ b/Scheduler/Filters/dll/Submission JobSize/SubmissionJobSize/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/exe/Activation FlexLM/app.config
+++ b/Scheduler/Filters/exe/Activation FlexLM/app.config
@@ -7,6 +7,10 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
       </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+		<bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
+	  </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Scheduler/Filters/exe/Activation HoldUntil/ActivationHoldUntil/App.config
+++ b/Scheduler/Filters/exe/Activation HoldUntil/ActivationHoldUntil/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/Filters/exe/Submission JobSize/SubmissionJobSize/App.config
+++ b/Scheduler/Filters/exe/Submission JobSize/SubmissionJobSize/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/HPCSchedulerBasics/HPCSchedulerBasics/app.config
+++ b/Scheduler/HPCSchedulerBasics/HPCSchedulerBasics/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/JobFinish/JobFinish/App.config
+++ b/Scheduler/JobFinish/JobFinish/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/JobProgress/JobProgress/app.config
+++ b/Scheduler/JobProgress/JobProgress/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/JobUse/JobUse/app.config
+++ b/Scheduler/JobUse/JobUse/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/REST/CSharpClient/CSharpClient/App.config
+++ b/Scheduler/REST/CSharpClient/CSharpClient/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/REST/CSharpClient2016/CSharpClient2016/App.config
+++ b/Scheduler/REST/CSharpClient2016/CSharpClient2016/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/ReconnectEvents/ReconnectEvents/app.config
+++ b/Scheduler/ReconnectEvents/ReconnectEvents/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/SubmitJobFast/SubmitJobFast/App.config
+++ b/Scheduler/SubmitJobFast/SubmitJobFast/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/SubmitTaskFast/SubmitTaskFast/App.config
+++ b/Scheduler/SubmitTaskFast/SubmitTaskFast/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scheduler/WaitForJob/WaitForJob/App.config
+++ b/Scheduler/WaitForJob/WaitForJob/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
change Microsoft.WindowsAzure.Storage version: bindingRedirect in App.config, 0.0.0.0-8.7.0.0 will be redirected to 8.4.0.0
Microsoft.WindowsAzure.Storage is deprecated and will be replaced in the new SDK version.